### PR TITLE
Fixed : Targeting SDK34 requires Context-based BroadcastReceivers Exported declaration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,7 +96,7 @@ dependencies {
   implementation 'com.huawei.hms:push:6.3.0.304'
 
   implementation 'com.google.android.material:material:1.6.0-alpha02'
-  implementation 'androidx.appcompat:appcompat:1.6.1'
+  implementation 'androidx.appcompat:appcompat:1.4.1'
   implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
   implementation 'androidx.annotation:annotation:1.3.0'
   implementation 'androidx.core:core-ktx:1.7.0'

--- a/app/src/main/java/ly/count/android/demo/App.java
+++ b/app/src/main/java/ly/count/android/demo/App.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 import android.os.Bundle;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 
@@ -293,6 +294,6 @@ public class App extends Application {
         };
         IntentFilter filter = new IntentFilter();
         filter.addAction(CountlyPush.SECURE_NOTIFICATION_BROADCAST);
-        registerReceiver(messageReceiver, filter, getPackageName() + COUNTLY_BROADCAST_PERMISSION_POSTFIX, null);
+        ContextCompat.registerReceiver(this,messageReceiver, filter, getPackageName() + COUNTLY_BROADCAST_PERMISSION_POSTFIX, null,ContextCompat.RECEIVER_NOT_EXPORTED);
     }
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -53,6 +53,7 @@ dependencies {
   implementation 'androidx.lifecycle:lifecycle-common:2.6.1'
   implementation 'androidx.lifecycle:lifecycle-process:2.6.1'
 
+  implementation "androidx.core:core:1.12.0"
   androidTestImplementation 'androidx.test:runner:1.5.2'
   androidTestImplementation 'androidx.test:rules:1.5.0'
   androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/sdk/src/main/java/ly/count/android/sdk/messaging/CountlyPush.java
+++ b/sdk/src/main/java/ly/count/android/sdk/messaging/CountlyPush.java
@@ -26,6 +26,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import androidx.core.content.ContextCompat;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -43,6 +44,8 @@ import ly.count.android.sdk.Countly;
 import ly.count.android.sdk.CountlyStore;
 import ly.count.android.sdk.ModuleLog;
 import ly.count.android.sdk.Utils;
+
+import static android.content.Context.RECEIVER_EXPORTED;
 
 /**
  * Just a public holder class for Messaging-related display logic, listeners, managers, etc.
@@ -784,7 +787,7 @@ public class CountlyPush {
             IntentFilter filter = new IntentFilter();
             filter.addAction(Countly.CONSENT_BROADCAST);
             BroadcastReceiver consentReceiver = new ConsentBroadcastReceiver();
-            countlyConfigPush.application.registerReceiver(consentReceiver, filter, countlyConfigPush.application.getPackageName() + COUNTLY_BROADCAST_PERMISSION_POSTFIX, null);
+            ContextCompat.registerReceiver(countlyConfigPush.application, consentReceiver, filter, countlyConfigPush.application.getPackageName() + COUNTLY_BROADCAST_PERMISSION_POSTFIX, null, ContextCompat.RECEIVER_NOT_EXPORTED);
         }
 
         if (countlyConfigPush.provider == Countly.CountlyMessagingProvider.HMS && getPushConsent(countlyConfigPush.application)) {


### PR DESCRIPTION
Fixes https://github.com/Countly/countly-sdk-android/issues/191
# Proposed Changes
- Add `androidx.core:core:+` dependency to the `sdk` module.
- Update calls to `registerReceiver` to use `ContextCompat.registerReceiver`